### PR TITLE
Property DateRangePicker::_template become protected instead private

### DIFF
--- a/src/DateRangePicker.php
+++ b/src/DateRangePicker.php
@@ -50,7 +50,7 @@ class DateRangePicker extends InputWidget
     /**
      * @var string the template to render. Used internally.
      */
-    private $_template = '{inputFrom}<span class="input-group-addon">{labelTo}</span>{inputTo}';
+    protected $_template = '{inputFrom}<span class="input-group-addon">{labelTo}</span>{inputTo}';
 
 
     /**


### PR DESCRIPTION
Property DateRangePicker::_template become protected instead private for possibility using it in extended classes.